### PR TITLE
Implement testing cases of wrk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ BASE_DIR := $(shell basename $(PWD))
 # Keep an existing GOPATH, make a private one if it is undefined
 GOPATH_DEFAULT := $(PWD)/.go
 export GOPATH ?= $(GOPATH_DEFAULT)
-PKG := git.openstack.org/openstack/stackube
+PKG := github/ZJU-SEL/capstan
 DEST := $(GOPATH)/src/$(PKG)
 
 GOFLAGS :=

--- a/examples/capstan.conf
+++ b/examples/capstan.conf
@@ -8,62 +8,19 @@
     "Workloads": [
         {
             "name": "nginx",
-            "image": "nginx:17.9",
+            "image": "nginx:1.7.9",
             "testingTool": {
                 "name": "wrk",
-                "image": "capstan/wrk:v1.0",
-                "steps": 5,
+                "image": "wadelee/wrk",
+                "steps": 10,
                 "testingCaseSet": [
-                    {
-                        "name": "benchmarkPodIPSameNode",
-                        "workloadArgs": "",
-                        "testingToolArgs": "wrk -t 8 -c 1000 -d 180 --latency ${ENDPOINT}"
-                    },
-                    {
-                        "name": "benchmarkVIPSameNode",
-                        "workloadArgs": "",
-                        "testingToolArgs": "wrk -t 8 -c 1000 -d 180 --latency ${ENDPOINT}"
-                    },
                     {
                         "name": "benchmarkPodIPDiffNode",
-                        "workloadArgs": "",
-                        "testingToolArgs": "wrk -t 8 -c 1000 -d 180 --latency ${ENDPOINT}"
+                        "testingToolArgs": "-t10 -c100 -d30 http://$(ENDPOINT)/"
                     },
                     {
-                        "name": "benchmarkVIPDiffNode",
-                        "workloadArgs": "",
-                        "testingToolArgs": "wrk -t 8 -c 1000 -d 180 --latency ${ENDPOINT}"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "iperf",
-            "image": "capstan/iperf-server:v1.0",
-            "testingTool": {
-                "name": "iperf",
-                "image": "capstan/iperf-client:v1.0",
-                "steps": 5,
-                "testingCaseSet": [
-                    {
-                        "name": "benchmarkTCPSameNode",
-                        "workloadArgs": "iperf -s",
-                        "testingToolArgs": "iperf -c ${ENDPOINT} -i 2 -t 60"
-                    },
-                    {
-                        "name": "benchmarkUDPSameNode",
-                        "workloadArgs": "iperf -s",
-                        "testingToolArgs": "iperf -c ${ENDPOINT} -u -i 2 -t 60 -b 1000M"
-                    },
-                    {
-                        "name": "benchmarkTCPDiffNode",
-                        "workloadArgs": "iperf -s",
-                        "testingToolArgs": "iperf -c ${ENDPOINT} -u -i 2 -t 60"
-                    },
-                    {
-                        "name": "benchmarkUDPDiffNode",
-                        "workloadArgs": "iperf -s",
-                        "testingToolArgs": "iperf -c ${ENDPOINT} -u -i 2 -t 60 -b 1000M"
+                        "name": "benchmarkPodIPSameNode",
+                        "testingToolArgs": "-t10 -c100 -d30 http://$(ENDPOINT)/"
                     }
                 ]
             }

--- a/pkg/build/wrk/Dockerfile
+++ b/pkg/build/wrk/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) YEAR The ZJU-SEL Authors.
+# Copyright (c) 2018 The ZJU-SEL Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,3 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+FROM williamyeh/wrk:4.0.2
+
+MAINTAINER The ZJU-SEL team
+
+ADD run_wrk.sh /run_wrk.sh
+
+ENTRYPOINT ["/run_wrk.sh"]

--- a/pkg/build/wrk/Makefile
+++ b/pkg/build/wrk/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) YEAR The ZJU-SEL Authors.
+# Copyright (c) 2018 The ZJU-SEL Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,3 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+TARGET = wrk
+REGISTRY ?= wadelee
+IMAGE = $(REGISTRY)/$(TARGET)
+DOCKER ?= docker
+VERSION ?= v0.1
+
+all: container
+
+container:
+	$(DOCKER) build -t $(REGISTRY)/$(TARGET):latest -t $(REGISTRY)/$(TARGET):$(VERSION) .
+
+push:
+	$(DOCKER) push $(REGISTRY)/$(TARGET):latest
+	$(DOCKER) push $(REGISTRY)/$(TARGET):$(VERSION)
+
+.PHONY: all container push
+
+clean:
+	$(DOCKER) rmi $(REGISTRY)/$(TARGET):latest $(REGISTRY)/$(TARGET):$(VERSION) || true

--- a/pkg/build/wrk/run_wrk.sh
+++ b/pkg/build/wrk/run_wrk.sh
@@ -1,4 +1,5 @@
-# Copyright (c) YEAR The ZJU-SEL Authors.
+#!/bin/sh
+# Copyright (c) 2018 The ZJU-SEL Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,3 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+/usr/local/bin/wrk $* && echo "Capstan Testing Done"

--- a/pkg/capstan/types/types.go
+++ b/pkg/capstan/types/types.go
@@ -25,6 +25,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+var (
+	// ResultsDir is the directory of testing results.
+	ResultsDir = "/tmp/capstan"
+)
+
 // Config is the internal representation of capstan configuration.
 type Config struct {
 	ResultsDir string `json:"ResultsDir"`
@@ -45,6 +50,9 @@ func ReadConfig(filepath string) (Config, error) {
 	err = json.Unmarshal(data, &config)
 	if err != nil {
 		return Config{}, errors.WithStack(err)
+	}
+	if config.ResultsDir != "" {
+		ResultsDir = config.ResultsDir
 	}
 	return config, nil
 }

--- a/pkg/workload/iperf/testingtool.go
+++ b/pkg/workload/iperf/testingtool.go
@@ -41,6 +41,7 @@ type TestingTool struct {
 	Workload       *Workload
 	Name           string
 	Image          string
+	CurrentTesting workload.TestingCase
 	Steps          time.Duration
 	TestingCaseSet []workload.TestingCase
 }
@@ -49,7 +50,7 @@ type TestingTool struct {
 var _ workload.Tool = &TestingTool{}
 
 // Run runs the defined testing case set for iperf testing tool (to adhere to workload.Tool interface).
-func (t *TestingTool) Run(kubeClient kubernetes.Interface, testingCase string) error {
+func (t *TestingTool) Run(kubeClient kubernetes.Interface, testingCase workload.TestingCase) error {
 	return errors.Errorf("Not implemented")
 }
 
@@ -61,13 +62,6 @@ func (t *TestingTool) GetTestingResults(kubeClient kubernetes.Interface) error {
 // Cleanup cleans up all resources created by a testing case for iperf testing tool (to adhere to workload.Tool interface).
 func (t *TestingTool) Cleanup(kubeClient kubernetes.Interface) error {
 	return errors.Errorf("Not implemented")
-}
-
-// Monitor continually checks for problems in the resources created by a
-// testing case (either because it won't schedule, too many failed executions, etc)
-// and sends the errors through the provided channel (to adhere to workload.Tool interface).
-func (t *TestingTool) Monitor(kubeClient kubernetes.Interface, testingErr chan error) {
-	testingErr <- errors.Errorf("Not implemented")
 }
 
 // GetName returns the name of iperf testing tool (to adhere to workload.Tool interface).

--- a/pkg/workload/nginx/manifests.go
+++ b/pkg/workload/nginx/manifests.go
@@ -1,0 +1,125 @@
+/*
+Copyright (c) 2018 The ZJU-SEL Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nginx
+
+const (
+	nginxPod = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Name }}
+  annotations:
+    capstan-workload: nginx
+    capstan-testingcase: {{ .TestingName }}
+  labels:
+    component: capstan
+    testing: {{ .Name }}
+  namespace: capstan
+spec:
+  containers:
+  - name: workload-nginx
+    image: {{ .Image }}
+    imagePullPolicy: Always
+    ports:
+    - containerPort: 80
+  restartPolicy: Never
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+    operator: Exists
+  - key: CriticalAddonsOnly
+    operator: Exists
+`
+	wrkPodAntiAffinity = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Name }}
+  annotations:
+    capstan-testing: wrk
+    capstan-testingcase: {{ .TestingName }}
+  labels:
+    component: capstan
+    testing: {{ .Name }}
+  namespace: capstan
+spec:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: testing
+            operator: In
+            values:
+            -  {{ .WorkloadName }}
+        topologyKey: "kubernetes.io/hostname"
+  containers:
+  - name: testing-wrk
+    image: {{ .Image }}
+    imagePullPolicy: Always
+    args: [{{ .Args }}]
+    env:
+    - name: ENDPOINT
+      value: {{ .PodIP }}
+  restartPolicy: Never
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+    operator: Exists
+  - key: CriticalAddonsOnly
+    operator: Exists
+`
+	wrkPodAffinity = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Name }}
+  annotations:
+    capstan-testing: wrk
+    capstan-testingcase: {{ .TestingName }}
+  labels:
+    component: capstan
+    testing: {{ .Name }}
+  namespace: capstan
+spec:
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: testing
+            operator: In
+            values:
+            -  {{ .WorkloadName }}
+        topologyKey: "kubernetes.io/hostname"
+  containers:
+  - name: testing-wrk
+    image: williamyeh/wrk
+    imagePullPolicy: Always
+    args: [{{ .Args }}]
+    env:
+    - name: ENDPOINT
+      value: {{ .PodIP }}
+  restartPolicy: Never
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+    operator: Exists
+  - key: CriticalAddonsOnly
+    operator: Exists
+`
+)

--- a/pkg/workload/nginx/testingtool.go
+++ b/pkg/workload/nginx/testingtool.go
@@ -17,23 +17,31 @@ limitations under the License.
 package nginx
 
 import (
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
 	"time"
 
+	"github.com/ZJU-SEL/capstan/pkg/capstan/types"
 	"github.com/ZJU-SEL/capstan/pkg/workload"
+	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
 const (
-	toolName = "wrk"
+	toolName               = "wrk"
+	benchmarkPodIPSameNode = "benchmarkPodIPSameNode"
+	benchmarkPodIPDiffNode = "benchmarkPodIPDiffNode"
 )
 
 // TestingCaseSet is the list of wrk defined testing case.
 var TestingCaseSet = []string{
 	"benchmarkPodIPSameNode",
-	"benchmarkVIPSameNode",
 	"benchmarkPodIPDiffNode",
-	"benchmarkVIPDiffNode",
 }
 
 // TestingTool represents the wrk testing tool.
@@ -42,6 +50,7 @@ type TestingTool struct {
 	Name           string
 	Image          string
 	Steps          time.Duration
+	CurrentTesting workload.TestingCase
 	TestingCaseSet []workload.TestingCase
 }
 
@@ -49,25 +58,114 @@ type TestingTool struct {
 var _ workload.Tool = &TestingTool{}
 
 // Run runs the defined testing case set for wrk testing tool (to adhere to workload.Tool interface).
-func (t *TestingTool) Run(kubeClient kubernetes.Interface, testingCase string) error {
-	return errors.Errorf("Not implemented")
+func (t *TestingTool) Run(kubeClient kubernetes.Interface, testingCase workload.TestingCase) error {
+	t.CurrentTesting = testingCase
+
+	// 1. start a workload for the testing case.
+	workloadPodName := t.workloadPodName(testingCase.Name)
+	tempWorkloadArgs := struct{ Name, TestingName, Image string }{
+		Name:        workloadPodName,
+		TestingName: testingCase.Name,
+		Image:       t.Workload.GetImage(),
+	}
+
+	nginxPodBytes, err := workload.ParseTemplate(nginxPod, tempWorkloadArgs)
+	if err != nil {
+		return errors.Wrapf(err, "unable to parse %v using %v", nginxPod, tempWorkloadArgs)
+	}
+
+	glog.V(4).Infof("Creating workload %q of testing case %s", workloadPodName, testingCase.Name)
+	if err := workload.CreatePod(kubeClient, nginxPodBytes); err != nil {
+		return errors.Wrapf(err, "unable to create the %s workload for testing case %s", t.Workload.GetName(), testingCase.Name)
+	}
+
+	// 2. get the pod ip of the workload until workload is running.
+	glog.V(4).Infof("Geting the pod ip of workload %s", workloadPodName)
+	podIP, err := t.getRunningPodIP(kubeClient, workloadPodName)
+	if err != nil {
+		return errors.Wrapf(err, "unable to find pod %s's ip created by the %s workload for testing case %s", workloadPodName, t.Workload.GetName(), testingCase.Name)
+	}
+
+	// 3. start a testing pod for testing the workload.
+	testingPodName := t.testingPodName(testingCase.Name)
+	testingPod, args := t.findTemplate(testingCase.Name)
+	tempTestingArgs := struct{ Name, TestingName, Image, WorkloadName, Args, PodIP string }{
+		Name:         testingPodName,
+		TestingName:  testingCase.Name,
+		Image:        t.GetImage(),
+		WorkloadName: workloadPodName,
+		Args:         workload.FomatArgs(args),
+		PodIP:        podIP,
+	}
+
+	testingPodBytes, err := workload.ParseTemplate(testingPod, tempTestingArgs)
+	if err != nil {
+		return errors.Wrapf(err, "unable to parse %v using %v", testingPod, tempTestingArgs)
+	}
+
+	glog.V(4).Infof("Creating testing pod %q of testing case %s", testingPodName, testingCase.Name)
+	if err := workload.CreatePod(kubeClient, testingPodBytes); err != nil {
+		return errors.Wrapf(err, "unable to create the testing pod for testing case %s", testingCase.Name)
+	}
+
+	return nil
 }
 
 //GetTestingResults gets the testing results of wrk testing case (to adhere to workload.Tool interface).
 func (t *TestingTool) GetTestingResults(kubeClient kubernetes.Interface) error {
-	return errors.Errorf("Not implemented")
+	name := t.testingPodName(t.CurrentTesting.Name)
+	for {
+		// Sleep between each poll
+		// TODO(mozhuli): Use a watcher instead of polling.
+		time.Sleep(30 * time.Second)
+
+		// Make sure there's a pod.
+		pod, err := kubeClient.CoreV1().Pods(workload.DefaultNamespace).Get(name, apismetav1.GetOptions{})
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// Make sure the pod isn't failing.
+		if isFailing, err := workload.IsPodFailing(pod); isFailing {
+			return err
+		}
+
+		// Check testing has done.
+		body, err := kubeClient.CoreV1().Pods(workload.DefaultNamespace).GetLogs(
+			name,
+			&v1.PodLogOptions{},
+		).Do().Raw()
+
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		glog.V(5).Infof("Checking testing has done:\n%s", string(body))
+		if workload.HasTestingDone(body) {
+			glog.V(4).Infof("Testing case %s has done", t.CurrentTesting.Name)
+			outdir := path.Join(types.ResultsDir, "workloads", t.Workload.GetName(), t.GetName(), t.CurrentTesting.Name)
+			if err = os.MkdirAll(outdir, 0755); err != nil {
+				return errors.WithStack(err)
+			}
+
+			outfile := path.Join(outdir, t.GetName()) + ".log"
+			if err = ioutil.WriteFile(outfile, body, 0644); err != nil {
+				return errors.WithStack(err)
+			}
+			return nil
+		}
+	}
 }
 
 // Cleanup cleans up all resources created by a testing case for wrk testing tool (to adhere to workload.Tool interface).
 func (t *TestingTool) Cleanup(kubeClient kubernetes.Interface) error {
-	return errors.Errorf("Not implemented")
-}
-
-// Monitor continually checks for problems in the resources created by a
-// testing case (either because it won't schedule, too many failed executions, etc)
-// and sends the errors through the provided channel (to adhere to workload.Tool interface).
-func (t *TestingTool) Monitor(kubeClient kubernetes.Interface, testingErr chan error) {
-	testingErr <- errors.Errorf("Not implemented")
+	if err := workload.DeletePod(kubeClient, t.testingPodName(t.CurrentTesting.Name)); err != nil {
+		return err
+	}
+	if err := workload.DeletePod(kubeClient, t.workloadPodName(t.CurrentTesting.Name)); err != nil {
+		return err
+	}
+	return nil
 }
 
 // GetName returns the name of wrk testing tool (to adhere to workload.Tool interface).
@@ -88,4 +186,55 @@ func (t *TestingTool) GetSteps() time.Duration {
 // GetTestingCaseSet returns the testing case set which the wrk testing tool will run (to adhere to workload.Tool interface).
 func (t *TestingTool) GetTestingCaseSet() []workload.TestingCase {
 	return t.TestingCaseSet
+}
+
+// getRunningPodIP finds the running pod's ip created by a workload, If no pod is found,
+// or if pod's status is not running, returns an error.
+func (t *TestingTool) getRunningPodIP(kubeClient kubernetes.Interface, name string) (string, error) {
+	n := 0
+	for {
+		// Sleep between each poll, which should give the workload enough time to create a Pod
+		// TODO(mozhuli): Use a watcher instead of polling.
+		time.Sleep(10 * time.Second)
+
+		// Make sure there's a pod.
+		pod, err := kubeClient.CoreV1().Pods(workload.DefaultNamespace).Get(name, apismetav1.GetOptions{})
+		if err != nil {
+			return "", errors.WithStack(err)
+		}
+
+		// Make sure the pod isn't failing.
+		if isFailing, err := workload.IsPodFailing(pod); isFailing {
+			return "", err
+		}
+
+		if pod.Status.Phase == v1.PodRunning {
+			return pod.Status.PodIP, nil
+		}
+
+		// return an error, if has not get the pod ip for 60 seconds.
+		if n > 5 {
+			return "", errors.Errorf("long time to get pod %s ip", name)
+		}
+		n++
+	}
+}
+
+// findTemplate returns the true testing tool template and arguments for different testing cases.
+func (t *TestingTool) findTemplate(name string) (string, string) {
+	if t.CurrentTesting.Name == benchmarkPodIPDiffNode {
+		return wrkPodAntiAffinity, t.CurrentTesting.TestingToolArgs
+	}
+	if t.CurrentTesting.Name == benchmarkPodIPSameNode {
+		return wrkPodAffinity, t.CurrentTesting.TestingToolArgs
+	}
+	return "", ""
+}
+
+func (t *TestingTool) workloadPodName(testingName string) string {
+	return strings.ToLower("capstan-" + t.Workload.GetName() + "-" + testingName)
+}
+
+func (t *TestingTool) testingPodName(testingName string) string {
+	return strings.ToLower("capstan-" + t.GetName() + "-" + testingName)
 }

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -23,6 +23,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+const (
+	// DefaultNamespace is the default namespace for capstan.
+	DefaultNamespace = "capstan"
+)
+
 // Interface should be implemented by a specific workload.
 type Interface interface {
 	// Run runs a testing workload.
@@ -38,15 +43,11 @@ type Interface interface {
 // Tool should be implemented by a testing tool.
 type Tool interface {
 	// Run runs the defined testing case set.
-	Run(kubeClient kubernetes.Interface, testingCase string) error
+	Run(kubeClient kubernetes.Interface, testingCase TestingCase) error
 	// GetTestingResults gets the testing results of a testing case.
 	GetTestingResults(kubeClient kubernetes.Interface) error
 	// Cleanup cleans up all resources created by a testing case.
 	Cleanup(kubeClient kubernetes.Interface) error
-	// Monitor continually checks for problems in the resources created by a
-	// testing case (either because it won't schedule, too many failed executions, etc)
-	// and sends the errors through the provided channel.
-	Monitor(kubeClient kubernetes.Interface, testingErr chan error)
 	// GetName returns the name of this testing tool.
 	GetName() string
 	// GetImage returns the image name of this testing tool.

--- a/pkg/workload/workload_helper.go
+++ b/pkg/workload/workload_helper.go
@@ -1,0 +1,152 @@
+/*
+Copyright (c) 2018 The ZJU-SEL Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workload
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kuberuntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+// ParseTemplate uses the obj to parse the strtmpl template.
+func ParseTemplate(strtmpl string, obj interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	tmpl, err := template.New("template").Parse(strtmpl)
+	if err != nil {
+		return nil, errors.Wrap(err, "error when parsing template")
+	}
+	err = tmpl.Execute(&buf, obj)
+	if err != nil {
+		return nil, errors.Wrap(err, "error when executing template")
+	}
+	return buf.Bytes(), nil
+}
+
+// CreatePod creates a pod using podBytes.
+func CreatePod(kubeClient kubernetes.Interface, podBytes []byte) error {
+	pod := &v1.Pod{}
+	if err := kuberuntime.DecodeInto(scheme.Codecs.UniversalDecoder(), podBytes, pod); err != nil {
+		return errors.Wrap(err, "unable to decode pod")
+	}
+
+	_, err := kubeClient.CoreV1().Pods(DefaultNamespace).Create(pod)
+	if err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return errors.WithStack(err)
+		}
+
+		if _, err = kubeClient.CoreV1().Pods(DefaultNamespace).Update(pod); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	return nil
+}
+
+// DeletePod deletes a pod with the name.
+func DeletePod(kubeClient kubernetes.Interface, name string) error {
+	if err := kubeClient.CoreV1().Pods(DefaultNamespace).Delete(name, apismetav1.NewDeleteOptions(0)); err != nil {
+		return errors.Wrapf(err, "failed to delete pod %v", name)
+	}
+
+	err := wait.Poll(500*time.Millisecond, 60*time.Second, func() (bool, error) {
+		_, err := kubeClient.CoreV1().Pods(DefaultNamespace).Get(name, apismetav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+
+			return false, err
+		}
+
+		return false, nil
+	})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
+// IsPodFailing returns whether a testing case pod is failing and isn't likely to succeed.
+// TODO(mozhuli): this may require more revisions as we get more experience with
+// various types of failures that can occur.
+func IsPodFailing(pod *v1.Pod) (bool, error) {
+	// Check if the pod is unschedulable
+	for _, cond := range pod.Status.Conditions {
+		if cond.Reason == "Unschedulable" {
+			return true, errors.Errorf("Can't schedule pod: %v", cond.Message)
+		}
+	}
+
+	for _, cstatus := range pod.Status.ContainerStatuses {
+		// Check if a container in the pod is restarting multiple times
+		if cstatus.RestartCount > 2 {
+			return true, errors.Errorf("Container %v has restarted unsuccessfully %v times", cstatus.Name, cstatus.RestartCount)
+
+		}
+
+		// Check if it can't fetch its image
+		if waiting := cstatus.State.Waiting; waiting != nil {
+			if waiting.Reason == "ImagePullBackOff" || waiting.Reason == "ErrImagePull" {
+				return true, errors.Errorf("Container %v is in state %v", cstatus.Name, waiting.Reason)
+
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// HasTestingDone checks the testing case has finished
+// or not(use the finish mark "Capstan Testing Done").
+func HasTestingDone(data []byte) bool {
+	scanner := bufio.NewScanner(bytes.NewBuffer(data))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "Capstan Testing Done" {
+			return true
+		}
+	}
+	return false
+}
+
+// FomatArgs fomats the config agrs to yaml agrs of kubernetes.
+func FomatArgs(agrs string) string {
+	ss := strings.Split(agrs, " ")
+	var str string
+	for i, s := range ss {
+		if i == len(ss)-1 {
+			str = str + fmt.Sprintf("\"%s\"", s)
+		} else {
+			str = str + fmt.Sprintf("\"%s\",", s)
+		}
+	}
+	return str
+}


### PR DESCRIPTION
Implement benchmarkPodIPDiffNode and benchmarkPodIPSameNode testing cases of wrk

The results can find in `/tmp/capstan`:
```
└── workloads
    └── nginx
        └── wrk
            ├── benchmarkPodIPDiffNode
            │   └── wrk.log
            └── benchmarkPodIPSameNode
                └── wrk.log
```

Signed-off-by: mozhuli <21621232@zju.edu.cn>