### PR TITLE
Fix some nits and use old glog revision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ BASE_DIR := $(shell basename $(PWD))
 # Keep an existing GOPATH, make a private one if it is undefined
 GOPATH_DEFAULT := $(PWD)/.go
 export GOPATH ?= $(GOPATH_DEFAULT)
-PKG := github/ZJU-SEL/capstan
+PKG := github.com/ZJU-SEL/capstan
 DEST := $(GOPATH)/src/$(PKG)
 
 GOFLAGS :=

--- a/pkg/workload/nginx/manifests.go
+++ b/pkg/workload/nginx/manifests.go
@@ -108,7 +108,7 @@ spec:
         topologyKey: "kubernetes.io/hostname"
   containers:
   - name: testing-wrk
-    image: williamyeh/wrk
+    image: {{ .Image }}
     imagePullPolicy: Always
     args: [{{ .Args }}]
     env:

--- a/pkg/workload/workload_helper.go
+++ b/pkg/workload/workload_helper.go
@@ -57,13 +57,7 @@ func CreatePod(kubeClient kubernetes.Interface, podBytes []byte) error {
 
 	_, err := kubeClient.CoreV1().Pods(DefaultNamespace).Create(pod)
 	if err != nil {
-		if !apierrors.IsAlreadyExists(err) {
-			return errors.WithStack(err)
-		}
-
-		if _, err = kubeClient.CoreV1().Pods(DefaultNamespace).Update(pod); err != nil {
-			return errors.WithStack(err)
-		}
+		return errors.WithStack(err)
 	}
 
 	return nil

--- a/vendor/github.com/golang/glog/README
+++ b/vendor/github.com/golang/glog/README
@@ -5,7 +5,7 @@ Leveled execution logs for Go.
 
 This is an efficient pure Go implementation of leveled logs in the
 manner of the open source C++ package
-	https://github.com/google/glog
+	http://code.google.com/p/google-glog
 
 By binding methods to booleans it is possible to use the log package
 without paying the expense of evaluating the arguments to the log.

--- a/vendor/github.com/golang/glog/glog.go
+++ b/vendor/github.com/golang/glog/glog.go
@@ -676,10 +676,7 @@ func (l *loggingT) output(s severity, buf *buffer, file string, line int, alsoTo
 		}
 	}
 	data := buf.Bytes()
-	if !flag.Parsed() {
-		os.Stderr.Write([]byte("ERROR: logging before flag.Parse: "))
-		os.Stderr.Write(data)
-	} else if l.toStderr {
+	if l.toStderr {
 		os.Stderr.Write(data)
 	} else {
 		if alsoToStderr || l.alsoToStderr || s >= l.stderrThreshold.get() {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -24,10 +24,10 @@
 			"revisionTime": "2018-01-12T09:26:16Z"
 		},
 		{
-			"checksumSHA1": "HmbftipkadrLlCfzzVQ+iFHbl6g=",
+			"checksumSHA1": "URsJa4y/sUUw/STmbeYx9EKqaYE=",
 			"path": "github.com/golang/glog",
-			"revision": "23def4e6c14b4da8ac2ed8007337bc5eb5007998",
-			"revisionTime": "2016-01-25T20:49:56Z"
+			"revision": "44145f04b68cf362d9c4df2182967c2275eaefed",
+			"revisionTime": "2014-09-23T20:47:00Z"
 		},
 		{
 			"checksumSHA1": "yqF125xVSkmfLpIVGrLlfE05IUk=",


### PR DESCRIPTION
1. Fix some nits
2. Use old glog revision for the known flag parse [issue](https://github.com/golang/glog/pull/13)

Signed-off-by: mozhuli <21621232@zju.edu.cn>